### PR TITLE
Usually we return the client secret as a GET param in the url, so not wi...

### DIFF
--- a/Model/Client.php
+++ b/Model/Client.php
@@ -138,7 +138,7 @@ class Client extends OAuthAppModel {
  */
 	public function newClientSecret() {
 		$length = 40;
-		$chars = '@#!%*+/-=ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+		$chars = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
 		$str = '';
 		$count = strlen($chars);
 		while ($length--) {


### PR DESCRIPTION
...se to use symbols as client_secret because the symbols get encoded.
