### PR TITLE
Allow the plugin to play nicely with UUIDs for the user_id

### DIFF
--- a/Model/AccessToken.php
+++ b/Model/AccessToken.php
@@ -39,8 +39,8 @@ class AccessToken extends OAuthAppModel {
 			),
 		),
 		'user_id' => array(
-			'numeric' => array(
-				'rule' => array('numeric'),
+			'notempty' => array(
+				'rule' => array('notempty'),
 			),
 		),
 		'expires' => array(

--- a/Model/AuthCode.php
+++ b/Model/AuthCode.php
@@ -39,8 +39,8 @@ class AuthCode extends OAuthAppModel {
 			),
 		),
 		'user_id' => array(
-			'numeric' => array(
-				'rule' => array('numeric'),
+			'notempty' => array(
+				'rule' => array('notempty'),
 			),
 		),
 		'redirect_uri' => array(

--- a/Model/RefreshToken.php
+++ b/Model/RefreshToken.php
@@ -39,8 +39,8 @@ class RefreshToken extends OAuthAppModel {
 			),
 		),
 		'user_id' => array(
-			'numeric' => array(
-				'rule' => array('numeric'),
+			'notempty' => array(
+				'rule' => array('notempty'),
 			),
 		),
 		'expires' => array(


### PR DESCRIPTION
It appears the oauth-php library already supports the user_id = string, so this was a matter of updating validation rules to allow non-int (actually non-empty) user_id fields in the oauth tables.
