### PR TITLE
Fix bug. Just rethrow exception

### DIFF
--- a/Controller/Component/OAuthComponent.php
+++ b/Controller/Component/OAuthComponent.php
@@ -366,7 +366,7 @@ class OAuthComponent extends Component implements IOAuth2Storage, IOAuth2Refresh
 				if (method_exists($e, 'sendHttpResponse')) {
 					$e->sendHttpResponse();
 				}
-				throw new $e;
+				throw $e;
 			}
 		}
 	}


### PR DESCRIPTION
The exception should be just rethrown instead of trying to create a new one from the current instance.
